### PR TITLE
Export stub_kms test support

### DIFF
--- a/lib/voynich/test_support.rb
+++ b/lib/voynich/test_support.rb
@@ -1,5 +1,5 @@
 module Voynich
-  module SpecSupport
+  module TestSupport
     module StubKMS
       def stub_kms_request
         allow(Voynich).to receive(:kms_client) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,12 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'voynich'
+require 'voynich/test_support'
 require 'database_cleaner'
 
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
-  config.include Voynich::SpecSupport::StubKMS
+  config.include Voynich::TestSupport::StubKMS
 
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction


### PR DESCRIPTION
Moved `StubKms` test support to under `lib` directory so that voynich users can use the support