### PR TITLE
Add model attribute generator and MIT license

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2016 Kazunori Kajihiro
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -89,3 +89,10 @@ model.secret_data # => {card_number: '1234567890123456'}
 - [ ] Path based tree structure
 - [ ] S3 adapter
 
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/degica/voynich.
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -7,16 +7,12 @@ Voynich is a secret storage library for Ruby on Rails backed by Amazon Key Manag
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'voynich'
+gem 'voynich', github: 'degica/voynich'
 ```
 
 And then execute:
 
     $ bundle
-
-Or install it yourself as:
-
-    $ gem install voynich
     
 ### Generate Migration File
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Voynich.configure(
 
 ## Usage
 
+Voynich provides 2 types of interfaces.
+
+### Storage interface
+
+`Storage` provides generic accessors for encrypted attributes.
+
 ```ruby
 ## Create new encrypted data
 ### `create` method creates a new data key using KMS API and save the encrypted version of the key,
@@ -53,14 +59,16 @@ data = Voynich::Storage.new.decrypt(uuid)
 
 ### ActiveModel integration
 
-```ruby
-class SomeModel < ActiveRecord::Base
-  include Voynich::ActiveModel::Model
-  
-  voynich_attribute :secret_data
-end
+If you use Voynich with ActiveRecord models, you can use `Voynich::ActiveModel::Model` module to integrate your model with Voynich tables. 
 
-model = SomeModel.new
+To use the module, run the following command. It will generate a migration file and add some lines to your model file.
+
+    $ rails g voynich:model_attribute YourModel model_attribute
+    
+Now the attribute is managed by Voynich
+
+```ruby
+model = YourModel.new
 # You can assign any type of data
 model.secret_data = {card_number: '1234567890123456'}
 
@@ -77,6 +85,7 @@ model.secret_data # => {card_number: '1234567890123456'}
 
 ## TODO
 
-- [] Data key rotation
-- [] Path based tree structure
-- [] S3 adapter
+- [ ] Data key rotation
+- [ ] Path based tree structure
+- [ ] S3 adapter
+

--- a/lib/generators/voynich/model_attribute_generator.rb
+++ b/lib/generators/voynich/model_attribute_generator.rb
@@ -1,0 +1,33 @@
+require "rails/generators/migration"
+require "rails/generators/active_record"
+
+module Voynich
+  class ModelAttributeGenerator < Rails::Generators::Base
+    argument :model_class_name, type: :string
+    argument :attribute_name, type: :string
+
+    def include_module
+      inject_into_file(model_file_path, after: %r{class\s+#{model_class_name}\s+<\s+ActiveRecord::Base\n}) do <<-'RUBY'
+  include Voynich::ActiveModel::Model
+RUBY
+      end
+    end
+
+    def add_voynich_attribute
+      inject_into_file(model_file_path, after: "include Voynich::ActiveModel::Model\n",) do <<-RUBY
+  voynich_attribute :#{attribute_name}
+RUBY
+      end
+    end
+
+    def generate_migration
+      generate "migration", "AddVoynich#{attribute_name.classify}ValueIdTo#{model_class_name.pluralize} voynich_#{attribute_name}_value_id:integer"
+    end
+
+    private
+
+    def model_file_path
+      File.join("app", "models", "#{model_class_name.underscore}.rb")
+    end
+  end
+end


### PR DESCRIPTION
Added a helper generator which generates a migration file and inject code for active model integration.

    $ rails g voynich:model_attribute Request created_at

this command generates the following file and code

### db/migrate/20160301030602_add_voynich_created_at_value_id_to_requests.rb

```diff
+class AddVoynichCreatedAtValueIdToRequests < ActiveRecord::Migration
+  def change
+    add_column :requests, :voynich_created_at_value_id, :integer
+  end
+end
```

### app/models/request.rb

```diff
class Request < ActiveRecord::Base
+  include Voynich::ActiveModel::Model
+  voynich_attribute :created_at
   belongs_to :profile
```