### PR TITLE
Dont use encoded secret

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ cache:
   bundler: true
 sudo: false
 rvm:
-- 2.2.5
-- 2.3.1
+- 2.3.7
+- 2.4.4
+- 2.5.1
 env:
   matrix:
   - AR_VERSION=4.2

--- a/lib/voynich.rb
+++ b/lib/voynich.rb
@@ -4,6 +4,7 @@ require "voynich/kms_data_key_client"
 require "voynich/active_model/model"
 require "voynich/storage"
 require "voynich/aes"
+require "voynich/encrypter"
 
 require 'aws-sdk'
 require 'active_support/core_ext/module/attribute_accessors'

--- a/lib/voynich/active_record/models/data_key.rb
+++ b/lib/voynich/active_record/models/data_key.rb
@@ -14,8 +14,8 @@ module Voynich
       before_validation :generate_data_key, if: -> (m) { m.ciphertext.nil? }
 
       def reencrypt!
-        result = client.reencrypt(ciphertext)
-        self.ciphertext = result.ciphertext
+        result = client.reencrypt(decode(ciphertext))
+        self.ciphertext = encode(result.ciphertext)
         save!
       end
 
@@ -37,14 +37,22 @@ module Voynich
 
       def generate_data_key
         result = client.generate
-        self.ciphertext = result.ciphertext
+        self.ciphertext = encode(result.ciphertext)
         self.plaintext  = result.plaintext
       end
 
       def decrypt_data_key
-        result = client.decrypt(ciphertext)
-        self.ciphertext = result.ciphertext
+        result = client.decrypt(decode(ciphertext))
+        self.ciphertext = encode(result.ciphertext)
         self.plaintext  = result.plaintext
+      end
+
+      def encode(data)
+        Base64.strict_encode64(data)
+      end
+
+      def decode(data)
+        Base64.decode64(data)
       end
     end
   end

--- a/lib/voynich/encrypter.rb
+++ b/lib/voynich/encrypter.rb
@@ -29,6 +29,8 @@ module Voynich
       end
 
       def secret
+        # For backward compatibility, we need to encode secret before passing it to the openssl lib.
+        # See https://github.com/degica/voynich/pull/11
         Base64.strict_encode64(encrypter.secret)
       end
     end

--- a/lib/voynich/encrypter.rb
+++ b/lib/voynich/encrypter.rb
@@ -1,0 +1,73 @@
+module Voynich
+  class Encrypter
+    class V1
+      attr_accessor :encrypter
+
+      def initialize(encrypter)
+        @encrypter = encrypter
+      end
+
+      def encrypt(plaintext)
+        enc = AES.new(secret[0..31], encrypter.auth_data).encrypt(plaintext)
+        {
+          v:  version,
+          c:  enc[:content],
+          t:  enc[:tag],
+          iv: enc[:iv],
+          ad: enc[:auth_data]
+        }
+      end
+
+      def decrypt(enc)
+        AES
+          .new(secret[0..31], encrypter.auth_data)
+          .decrypt(enc["c"], iv: enc["iv"], tag: enc["t"])
+      end
+
+      def version
+        1
+      end
+
+      def secret
+        Base64.strict_encode64(encrypter.secret)
+      end
+    end
+
+    class V2 < V1
+      def version
+        2
+      end
+
+      def secret
+        encrypter.secret
+      end
+    end
+
+    attr_accessor :secret, :auth_data
+
+    def initialize(secret, adata)
+      @secret = secret
+      @auth_data = adata
+    end
+
+    def encrypt(plaintext, version: 2)
+      impl(version).encrypt(plaintext).to_json
+    end
+
+    def decrypt(enc_str)
+      enc = JSON.parse(enc_str)
+      impl(enc["v"]).decrypt(enc)
+    end
+
+    private
+
+    def impl(version)
+      case version
+      when 1, nil
+        V1.new(self)
+      when 2
+        V2.new(self)
+      end
+    end
+  end
+end

--- a/lib/voynich/kms_data_key_client.rb
+++ b/lib/voynich/kms_data_key_client.rb
@@ -9,32 +9,24 @@ module Voynich
     end
 
     def decrypt(ciphertext)
-      response = kms_client.decrypt(ciphertext_blob: decode(ciphertext))
-      Result.new(encode(response.plaintext), ciphertext)
+      response = kms_client.decrypt(ciphertext_blob: ciphertext)
+      Result.new(response.plaintext, ciphertext)
     end
 
     def generate
       response = kms_client.generate_data_key(key_id: cmk_id, key_spec: 'AES_256')
-      Result.new(encode(response.plaintext), encode(response.ciphertext_blob))
+      Result.new(response.plaintext, response.ciphertext_blob)
     end
 
     def reencrypt(ciphertext)
       response = kms_client.re_encrypt(
-        ciphertext_blob: decode(ciphertext),
+        ciphertext_blob: ciphertext,
         destination_key_id: cmk_id
       )
-      Result.new(nil, encode(response.ciphertext_blob))
+      Result.new(nil, response.ciphertext_blob)
     end
 
     private
-
-    def encode(data)
-      Base64.strict_encode64(data)
-    end
-
-    def decode(data)
-      Base64.decode64(data)
-    end
 
     def kms_client
       @kms_client ||= Voynich.kms_client

--- a/lib/voynich/test_support.rb
+++ b/lib/voynich/test_support.rb
@@ -1,13 +1,16 @@
+require 'securerandom'
+
 module Voynich
   module TestSupport
     module StubKMS
       def stub_kms_request
+        secret = SecureRandom.random_bytes(32)
         allow(Voynich).to receive(:kms_client) do
           client = Aws::KMS::Client.new(stub_responses: true)
           client.stub_responses(:generate_data_key,
-                                plaintext: 'fourty length encoded plaintext data key',
+                                plaintext: secret,
                                 ciphertext_blob: 'generated ciphertext blob')
-          client.stub_responses(:decrypt, plaintext: 'fourty length encoded plaintext data key')
+          client.stub_responses(:decrypt, plaintext: secret)
           client.stub_responses(:re_encrypt, ciphertext_blob: 'reencrypted ciphertext blob')
           client
         end

--- a/spec/lib/active_record/models/data_key_spec.rb
+++ b/spec/lib/active_record/models/data_key_spec.rb
@@ -6,20 +6,20 @@ module Voynich::ActiveRecord
 
     before do
       allow_any_instance_of(Voynich::KMSDataKeyClient).to receive(:generate) {
-        Voynich::KMSDataKeyClient::Result.new("encoded generated plaintext", "encoded generated ciphertext")
+        Voynich::KMSDataKeyClient::Result.new("generated plaintext", "generated ciphertext")
       }
       allow_any_instance_of(Voynich::KMSDataKeyClient).to receive(:decrypt) {
-        Voynich::KMSDataKeyClient::Result.new("encoded decrypted plaintext", "encoded ciphertext")
+        Voynich::KMSDataKeyClient::Result.new("decrypted plaintext", "ciphertext")
       }
       allow_any_instance_of(Voynich::KMSDataKeyClient).to receive(:reencrypt) {
-        Voynich::KMSDataKeyClient::Result.new(nil, "encoded reencrypted ciphertext")
+        Voynich::KMSDataKeyClient::Result.new(nil, "reencrypted ciphertext")
       }
     end
 
     describe "#reencrypt!" do
       it "re-encrypt and save ciphertext" do
         data_key.reencrypt!
-        expect(data_key.ciphertext).to eq "encoded reencrypted ciphertext"
+        expect(data_key.ciphertext).to eq Base64.strict_encode64("reencrypted ciphertext")
       end
     end
 
@@ -35,12 +35,12 @@ module Voynich::ActiveRecord
 
       context "when ciphertext doesn't exist" do
         let(:data_key) { DataKey.new(name: 'data_key', cmk_id: Voynich.kms_cmk_id) }
-        it { is_expected.to eq "encoded generated plaintext" }
+        it { is_expected.to eq "generated plaintext" }
       end
 
       context "when ciphertext exists" do
         before { data_key }
-        it { expect(DataKey.first.plaintext).to eq "encoded decrypted plaintext" }
+        it { expect(DataKey.first.plaintext).to eq "decrypted plaintext" }
       end
     end
   end

--- a/spec/lib/kms_data_key_client_spec.rb
+++ b/spec/lib/kms_data_key_client_spec.rb
@@ -16,10 +16,6 @@ module Voynich
       end
     end
 
-    def encode(d)
-      Base64.strict_encode64(d)
-    end
-
     def result(plain_blob, cipher_blob)
       described_class::Result.new(plain_blob, cipher_blob)
     end

--- a/spec/lib/kms_data_key_client_spec.rb
+++ b/spec/lib/kms_data_key_client_spec.rb
@@ -16,10 +16,12 @@ module Voynich
       end
     end
 
+    def encode(d)
+      Base64.strict_encode64(d)
+    end
+
     def result(plain_blob, cipher_blob)
-      plain  = plain_blob.nil?  ? nil : Base64.strict_encode64(plain_blob)
-      cipher = cipher_blob.nil? ? nil : Base64.strict_encode64(cipher_blob)
-      described_class::Result.new(plain, cipher)
+      described_class::Result.new(plain_blob, cipher_blob)
     end
 
     describe "#generate" do
@@ -29,7 +31,7 @@ module Voynich
     end
 
     describe "#decrypt" do
-      subject { kms_data_key_client.decrypt(Base64.strict_encode64("ciphertext blob")) }
+      subject { kms_data_key_client.decrypt("ciphertext blob") }
       it { is_expected.to eq result("decrypted plaintext blob", "ciphertext blob") }
     end
 


### PR DESCRIPTION
Fix #10

## Problem

since ruby 2.4, The openssl library raises an exception if secret key size is not 32 bytes. https://github.com/ruby/ruby/commit/ce635262f53b760284d56bb1027baebaaec175d1

## Why

The AWS KMS client gives raw 32 bytes data without encoding but voynich uses base64 encoded version of the byte data for AES secret.
Ruby 2.3 truncates the secret length to 32 bytes if secret size is longer than 32 bytes.

## Fix

The easiest fix is just truncating the AES secret before passing it to the openssl lib. But this way has a security problem which is that the value space of the encoded secret is less than 32 bytes i.e. the encoded secret is weaker than what it should be.

So We need to use the raw 32 byte secret returned by KMS as-is. Of course, this way is a breaking change so I implemented versioned encryption where if the encryption is done before this fix, voynich decrypts in a previous way with encoded and truncated secret