### PR TITLE
Add serializer option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ cache:
   bundler: true
 sudo: false
 rvm:
-- 2.3.7
-- 2.4.4
-- 2.5.1
+- 2.4.6
+- 2.5.5
+- 2.6.3
 env:
   matrix:
   - AR_VERSION=4.2

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem "sqlite3"
   gem 'database_cleaner'
 end
 # Specify your gem's dependencies in voynich.gemspec

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -1,2 +1,3 @@
 gem 'activerecord', '~> 4.2.0'
 gem 'activesupport', '~> 4.2.0'
+gem "sqlite3", "~> 1.3.10"

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -1,2 +1,3 @@
 gem 'activerecord', '~> 5.0.0'
 gem 'activesupport', '~> 5.0.0'
+gem "sqlite3", "~> 1.3.10"

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -1,2 +1,3 @@
 gem 'activerecord', '~> 5.1.0'
 gem 'activesupport', '~> 5.1.0'
+gem "sqlite3", "~> 1.3.10"

--- a/gemfiles/5.2.gemfile
+++ b/gemfiles/5.2.gemfile
@@ -1,2 +1,3 @@
 gem 'activerecord', '~> 5.2.0'
 gem 'activesupport', '~> 5.2.0'
+gem "sqlite3", "~> 1.4.0"

--- a/lib/voynich/active_model/model.rb
+++ b/lib/voynich/active_model/model.rb
@@ -29,6 +29,7 @@ module Voynich
           value = send(column_name) || send("build_#{column_name}")
           value.context = voynich_context(name)
           value.plain_value = iv
+          value.serializer = options[:serializer]
           value.save!
         end
       end
@@ -36,7 +37,8 @@ module Voynich
       VOYNICH_DEFAULT_OPTIONS = {
         column_prefix: 'voynich_',
         column_suffix: '_value',
-        context: nil
+        context: nil,
+        serializer: nil
       }
 
       module ClassMethods
@@ -66,6 +68,7 @@ module Voynich
             return iv unless iv.nil?
             return nil if value.nil?
             value.context = voynich_context(name)
+            value.serializer = options[:serializer]
             instance_variable_set(:"@#{name}", value.decrypt)
           end
 

--- a/lib/voynich/active_record/models/value.rb
+++ b/lib/voynich/active_record/models/value.rb
@@ -5,7 +5,7 @@ module Voynich
     class Value < ::ActiveRecord::Base
       self.table_name_prefix = 'voynich_'
 
-      attr_accessor :plain_value, :context
+      attr_accessor :plain_value, :context, :serializer
 
       belongs_to :data_key, required: true, class_name: "Voynich::ActiveRecord::DataKey"
 
@@ -28,7 +28,7 @@ module Voynich
       private
 
       def encrypter
-        @encrypter ||= Encrypter.new(data_key.plaintext, (context || {}).to_json)
+        @encrypter ||= Encrypter.new(data_key.plaintext, (context || {}).to_json, serializer: serializer)
       end
 
       def find_or_create_data_key

--- a/lib/voynich/aes.rb
+++ b/lib/voynich/aes.rb
@@ -7,10 +7,10 @@ module Voynich
     CIPHER_MODE = 'aes-256-gcm'
     DEFAULT_SERIALIZER = Marshal
 
-    def initialize(secret, adata, serializer: DEFAULT_SERIALIZER)
+    def initialize(secret, adata, serializer:)
       @secret = secret
       @auth_data = adata
-      @serializer = serializer
+      @serializer = serializer || DEFAULT_SERIALIZER
     end
 
     def encrypt(plaintext)

--- a/lib/voynich/encrypter.rb
+++ b/lib/voynich/encrypter.rb
@@ -8,7 +8,8 @@ module Voynich
       end
 
       def encrypt(plaintext)
-        enc = AES.new(secret[0..31], encrypter.auth_data).encrypt(plaintext)
+        enc = AES.new(secret[0..31], encrypter.auth_data, serializer: encrypter.serializer).
+                encrypt(plaintext)
         {
           v:  version,
           c:  enc[:content],
@@ -20,7 +21,7 @@ module Voynich
 
       def decrypt(enc)
         AES
-          .new(secret[0..31], encrypter.auth_data)
+          .new(secret[0..31], encrypter.auth_data, serializer: encrypter.serializer)
           .decrypt(enc["c"], iv: enc["iv"], tag: enc["t"])
       end
 
@@ -45,11 +46,12 @@ module Voynich
       end
     end
 
-    attr_accessor :secret, :auth_data
+    attr_accessor :secret, :auth_data, :serializer
 
-    def initialize(secret, adata)
+    def initialize(secret, adata, serializer: nil)
       @secret = secret
       @auth_data = adata
+      @serializer = serializer
     end
 
     def encrypt(plaintext, version: 2)

--- a/spec/lib/active_model/model_spec.rb
+++ b/spec/lib/active_model/model_spec.rb
@@ -10,7 +10,10 @@ module Voynich::ActiveModel
       t.uuid ||= SecureRandom.hex
     end
 
-    voynich_attribute :secret
+    # JSON serializer, no context
+    voynich_attribute :secret, serializer: JSON
+
+    # Marshal serializer (default), with context
     voynich_attribute :auth_secret, context: ->(m) { {uuid: m.uuid} }
   end
 
@@ -49,6 +52,7 @@ module Voynich::ActiveModel
         it "stores secret in voynich table" do
           expect(Voynich::ActiveRecord::Value.count).to eq 1
           value = Voynich::ActiveRecord::Value.first
+          value.serializer = JSON
           expect(value.decrypt).to eq "super secret information"
           expect(value.data_key).to be_a Voynich::ActiveRecord::DataKey
         end
@@ -60,6 +64,7 @@ module Voynich::ActiveModel
 
           expect(Voynich::ActiveRecord::Value.count).to eq 1
           value = Voynich::ActiveRecord::Value.first
+          value.serializer = JSON
           expect(value.decrypt).to eq "yet another secret information"
         end
 

--- a/voynich.gemspec
+++ b/voynich.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_dependency "aws-sdk", "~> 2.2"


### PR DESCRIPTION
Add `serialier` option to `voynich_attribute`:

```
class MyModel < ApplicationRecord
  voynich_attribute :secret, serializer: JSON
end
```

The default serializer remains to be Marshal for backward compatibility.
I also made some changes to development gem dependencies to make travis pass. 