### PR TITLE
Use persistent connection for AWS

### DIFF
--- a/lib/voynich.rb
+++ b/lib/voynich.rb
@@ -28,10 +28,11 @@ module Voynich
     self.aws_access_key_id = config[:aws_access_key_id]
     self.aws_secret_access_key = config[:aws_secret_access_key]
     self.aws_region = config[:aws_region]
+    @@kms_client = nil
   end
 
   def self.kms_client
-    if self.aws_access_key_id.present?
+    @@kms_client ||= if self.aws_access_key_id.present?
       credentials = Aws::Credentials.new(self.aws_access_key_id, self.aws_secret_access_key)
       Aws::KMS::Client.new(region: self.aws_region, credentials: credentials)
     else

--- a/spec/voynich_spec.rb
+++ b/spec/voynich_spec.rb
@@ -4,4 +4,28 @@ describe Voynich do
   it 'has a version number' do
     expect(Voynich::VERSION).not_to be nil
   end
+
+  describe '#kms_client' do
+    before do
+      allow(Aws::KMS::Client).to receive(:new) { double("kms client") }
+      Voynich.configure(retion: 'ap-northeast-1')
+    end
+
+    it 'should initialize Aws::KMS:Client once' do
+      expect(Aws::KMS::Client).to receive(:new).once
+      client1 = Voynich.kms_client
+      client2 = Voynich.kms_client
+      expect(client1).to eq(client2)
+    end
+
+    it 'should re-initialize Aws::KMS:Client after #configure' do
+      expect(Aws::KMS::Client).to receive(:new).twice
+      client1 = Voynich.kms_client
+      client2 = Voynich.kms_client
+      Voynich.configure(retion: 'ap-northeast-1')
+      client3 = Voynich.kms_client
+      expect(client1).to eq(client2)
+      expect(client1).not_to eq(client3)
+    end
+  end
 end


### PR DESCRIPTION
This PR resolves #14 by keeping a KMS client in a class varible.