### PR TITLE
Bump rake development dependency

### DIFF
--- a/voynich.gemspec
+++ b/voynich.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_dependency "aws-sdk-kms", "~> 1.36"
   spec.add_dependency "activesupport", ">= 4.2"


### PR DESCRIPTION
The 10.x branch of rake has an unresolved CVE, so bumping to 13 to resolve this.

Relevant advisory: https://github.com/advisories/GHSA-jppv-gw3r-w3q8